### PR TITLE
ganglia link on node page

### DIFF
--- a/crowbar_framework/app/models/ganglia_service.rb
+++ b/crowbar_framework/app/models/ganglia_service.rb
@@ -62,7 +62,11 @@ class GangliaService < ServiceObject
           tnodes.each do |n|
             next if n.nil?
             node = NodeObject.find_node_by_name(n)
-            server_ip = node.get_network_by_type("admin")["address"]
+            if node.get_network_by_type("public")["address"].nil? or node.get_network_by_type("public")["address"].empty?
+              server_ip = node.get_network_by_type("admin")["address"]
+            else
+              server_ip = node.get_network_by_type("public")["address"]
+            end
           end
         end
 


### PR DESCRIPTION
when using the Dell Hadoop RA, the only access to the crowbar UI is via a 'public' IP.  by default the ganglia link on a node page points to the 'admin' IP of the admin node.  this commit changes the link to use the 'public' IP if it's been configured, otherwise is falls back to the 'admin' IP.
