### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [9/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-ganglia.json
+++ b/chef/data_bags/crowbar/bc-template-ganglia.json
@@ -9,6 +9,10 @@
   "deployment": {
     "ganglia": {
       "crowbar-revision": 0,
+      "element_states": {
+        "ganglia-server": [ "readying", "ready", "applying" ],
+        "ganglia-client": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "ganglia-server", "ganglia-client" ]

--- a/chef/data_bags/crowbar/bc-template-ganglia.schema
+++ b/chef/data_bags/crowbar/bc-template-ganglia.schema
@@ -28,6 +28,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-ganglia.json   |    4 ++++
 chef/data_bags/crowbar/bc-template-ganglia.schema |   10 ++++++++++
 2 files changed, 14 insertions(+), 0 deletions(-)
