### PR TITLE
Move Nav into a database and adjust imaged locationalization [3/15]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -28,15 +28,6 @@ crowbar:
   run_order: 70
   chef_order: 1040
 
-locale_additions:
-  en:
-    barclamp:
-      ganglia:
-        edit_attributes: 
-          attributes: Attributes
-        edit_deployment: 
-          deployment: Deployment
-
 debs:
   pkgs:
     - ganglia-monitor

--- a/crowbar_framework/config/locales/ganglia/en.yml
+++ b/crowbar_framework/config/locales/ganglia/en.yml
@@ -1,0 +1,21 @@
+# Copyright 2012, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+en:
+  barclamp:
+    ganglia:
+      edit_attributes: 
+        attributes: Attributes
+      edit_deployment: 
+        deployment: Deployment


### PR DESCRIPTION
This work surfaced as part of the exploration to ensure that
multiple barclamps could contribute migrations (they can!)

Navigation has moved from the config/navigation into database
migrations that populate the navs table.  This means that nav
is no longer part of crowbar.yml.

Localization files are now unique per barclamp and not injected
during the barclamp import.  This provides more flexiblity and
easier management.  Localizations are no longer part of the crowbar.yml.

Documentation for the changes IS PROVIDED in the book-developersguide file.

For now, you need to rake db:migrate to get these changes!

 crowbar.yml                                     |    9 ---------
 crowbar_framework/config/locales/ganglia/en.yml |   21 +++++++++++++++++++++
 2 files changed, 21 insertions(+), 9 deletions(-)
