### PR TITLE
Move the crowbar.yml layout to v2 [7/27]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -23,7 +23,7 @@ barclamp:
     - crowbar
 
 crowbar:
-  layout: 1
+  layout: 2
   order: 100
   run_order: 70
   chef_order: 1040

--- a/crowbar_framework/doc/default/ganglia/barclamp-info.md
+++ b/crowbar_framework/doc/default/ganglia/barclamp-info.md
@@ -1,0 +1,6 @@
+### Ganglia Barclamp
+
+This barclamp install the Ganglia performance monitoring server and clients.
+
+
+

--- a/crowbar_framework/doc/default/ganglia/licenses.md
+++ b/crowbar_framework/doc/default/ganglia/licenses.md
@@ -1,0 +1,10 @@
+### Ganglia Barclamp Licenses
+
+This file contains information (if updated by the barclamp authors!) about the licenses that apply to your installation.
+
+The following dependencies are required:
+
+* ?
+
+
+

--- a/crowbar_framework/doc/ganglia.yml
+++ b/crowbar_framework/doc/ganglia.yml
@@ -1,0 +1,11 @@
+# theses are the default meta_data values
+license:    Apache 2
+copyright:  2012 by Dell, Inc
+date:       July 25, 2012
+
+crowbar+book-barclamps:
+  ganglia+barclamp-info
+    
+crowbar+book-licenses:
+  crowbar+licenses-crowbar-meta:
+    ganglia+licenses


### PR DESCRIPTION
Recent changes to add the database required us to update
the layout version.

I also added a doc skeleton while I was touching everything

 crowbar.yml                                        |    2 +-
 .../doc/default/ganglia/barclamp-info.md           |    6 ++++++
 crowbar_framework/doc/default/ganglia/licenses.md  |   10 ++++++++++
 crowbar_framework/doc/ganglia.yml                  |   11 +++++++++++
 4 files changed, 28 insertions(+), 1 deletions(-)
